### PR TITLE
Add collapsible CRM layout components

### DIFF
--- a/frontend/src/app/dashboard-example/page.tsx
+++ b/frontend/src/app/dashboard-example/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import AppLayout from '@/components/layout/AppLayout'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { BarChart2, CheckCircle } from 'lucide-react'
+
+export default function DashboardPage() {
+  return (
+    <AppLayout>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Today's Tasks</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2 text-sm">
+              <li className="flex items-center justify-between">
+                <span>Follow up with new lead</span>
+                <CheckCircle className="h-4 w-4 text-muted-foreground" />
+              </li>
+              <li className="flex items-center justify-between">
+                <span>Finalize contract draft</span>
+                <CheckCircle className="h-4 w-4 text-muted-foreground" />
+              </li>
+              <li className="flex items-center justify-between">
+                <span>Schedule meeting with traders</span>
+                <CheckCircle className="h-4 w-4 text-muted-foreground" />
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
+        <Card className="md:col-span-1 lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Revenue Chart</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex h-64 items-center justify-center rounded-md border-2 border-dashed">
+              <BarChart2 className="h-8 w-8 text-muted-foreground" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  )
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useState } from 'react'
+import Sidebar from './Sidebar'
+import Topbar from './Topbar'
+
+interface AppLayoutProps {
+  children: React.ReactNode
+}
+
+export default function AppLayout({ children }: AppLayoutProps) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  const toggle = () => setCollapsed(prev => !prev)
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden bg-background">
+      <Sidebar collapsed={collapsed} onCollapse={toggle} />
+      <div className="flex flex-1 flex-col">
+        <Topbar onMenuToggle={toggle} />
+        <main className="flex-1 overflow-y-auto p-4 sm:p-6">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Home,
+  FileText,
+  Building,
+  Users,
+  BarChart2,
+  Settings,
+  ChevronLeft,
+  ChevronRight,
+  Truck
+} from 'lucide-react'
+
+interface SidebarProps {
+  collapsed: boolean
+  onCollapse: () => void
+}
+
+const menuItems = [
+  { href: '/dashboard', label: 'Dashboard', icon: Home },
+  { href: '/contracts', label: 'Contracts', icon: FileText },
+  { href: '/counterparties', label: 'Counterparties', icon: Building },
+  { href: '/traders', label: 'Traders', icon: Users },
+  { href: '/reports', label: 'Reports', icon: BarChart2 },
+  { href: '/settings', label: 'Settings', icon: Settings }
+]
+
+export default function Sidebar({ collapsed, onCollapse }: SidebarProps) {
+  const pathname = usePathname()
+
+  return (
+    <aside
+      className={cn(
+        'flex flex-col border-r bg-card transition-all duration-300',
+        collapsed ? 'w-16' : 'w-64'
+      )}
+    >
+      <div className="flex h-16 items-center justify-between px-3">
+        <Link href="/dashboard" className="flex items-center gap-2">
+          <Truck className="h-6 w-6 text-primary" />
+          {!collapsed && <span className="text-xl font-bold">NextCRM</span>}
+        </Link>
+        <Button variant="ghost" size="icon" onClick={onCollapse}>
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4" />
+          ) : (
+            <ChevronLeft className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+      <nav className="flex-1 space-y-1 px-2 py-4">
+        {menuItems.map(item => {
+          const active = pathname === item.href
+          const Icon = item.icon
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-muted',
+                active ? 'bg-muted text-foreground' : 'text-muted-foreground'
+              )}
+            >
+              <Icon className="h-5 w-5" />
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          )
+        })}
+      </nav>
+    </aside>
+  )
+}

--- a/frontend/src/components/layout/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { Bell, Menu, Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { useAuth, useLogout } from '@/hooks/use-auth'
+import { getInitials } from '@/lib/utils'
+
+interface TopbarProps {
+  onMenuToggle?: () => void
+}
+
+export default function Topbar({ onMenuToggle }: TopbarProps) {
+  const { user } = useAuth()
+  const logout = useLogout()
+
+  return (
+    <header className="sticky top-0 z-20 flex h-16 items-center gap-4 border-b bg-background px-4 shadow-sm sm:px-6">
+      {onMenuToggle && (
+        <Button variant="ghost" size="icon" className="sm:hidden" onClick={onMenuToggle}>
+          <Menu className="h-5 w-5" />
+        </Button>
+      )}
+      <div className="relative w-full max-w-md">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input placeholder="Search..." className="pl-9" />
+      </div>
+      <div className="ml-auto flex items-center space-x-2">
+        <Button variant="ghost" size="icon">
+          <Bell className="h-5 w-5" />
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="rounded-full">
+              <Avatar className="h-8 w-8">
+                <AvatarImage src="" alt={user?.username || ''} />
+                <AvatarFallback>{getInitials(user?.username || 'U')}</AvatarFallback>
+              </Avatar>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>{user?.username}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => logout.mutate()}>Sign out</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add `AppLayout`, `Sidebar`, and `Topbar` components for a responsive CRM shell
- provide example dashboard page under `dashboard-example`
- demonstrate collapsible sidebar, sticky topbar, and basic cards

## Testing
- `npm run type-check` *(fails: Cannot find modules)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847efb96ce4832b925dfbdc34a5646f